### PR TITLE
fix: skip image regeneration on upload retry to save credits

### DIFF
--- a/agent/worker/processor.py
+++ b/agent/worker/processor.py
@@ -766,12 +766,40 @@ async def _handle_generate_character_image(client, req: dict) -> dict:
         return {"error": "Character not found"}
 
     pid = req.get("project_id", "0")
+    entity_type = char.get("entity_type", "character")
+
+    # ── Fast path: image already generated, just need upload for UUID ──
+    # If reference_image_url exists but media_id is missing, the image was
+    # already generated on a previous attempt — skip generation (saves credits)
+    # and just retry the upload + UUID extraction.
+    existing_url = char.get("reference_image_url")
+    if existing_url and not char.get("media_id"):
+        logger.info("%s '%s' already has image, retrying upload only (saving credits)", entity_type, char["name"])
+        upload_mid = await _upload_character_image(client, {
+            "name": char["name"],
+            "reference_image_url": existing_url,
+        }, pid)
+
+        if upload_mid:
+            await crud.update_character(char["id"], media_id=upload_mid)
+            logger.info("%s '%s' upload retry succeeded: media_id=%s", entity_type, char["name"], upload_mid[:30])
+            return {"data": {"media": [{"name": upload_mid}]}}
+
+        # Upload still failed — try extracting UUID from the GCS URL as last resort
+        uuid_from_url = _extract_uuid_from_url(existing_url)
+        if uuid_from_url:
+            await crud.update_character(char["id"], media_id=uuid_from_url)
+            logger.info("%s '%s' extracted UUID from URL: media_id=%s", entity_type, char["name"], uuid_from_url)
+            return {"data": {"media": [{"name": uuid_from_url}]}}
+
+        return {"error": f"Upload retry failed for {char['name']} — image exists but cannot get UUID media_id"}
+
+    # ── Normal path: generate image from scratch ──
     # Prefer image_prompt (detailed generation prompt) over description
     prompt = char.get("image_prompt") or f"Character reference: {char['name']}. {char.get('description', '')}"
 
     project = await crud.get_project(pid) if pid != "0" else None
     tier = project.get("user_paygate_tier", "PAYGATE_TIER_TWO") if project else "PAYGATE_TIER_TWO"
-    entity_type = char.get("entity_type", "character")
     aspect = _reference_aspect_ratio(entity_type)
 
     result = await client.generate_images(
@@ -799,10 +827,14 @@ async def _handle_generate_character_image(client, req: dict) -> dict:
                             entity_type, char["name"], aspect.split("_")[-1].lower(),
                             upload_mid[:30] if upload_mid else "?")
             else:
-                # Upload failed — store ref URL but NOT a bad media_id.
-                # This forces retry on next scene image gen (reference blocking will catch it).
+                # Upload failed — store ref URL, then try UUID extraction from GCS URL
                 await crud.update_character(char["id"], reference_image_url=output_url)
-                logger.warning("%s '%s' upload failed, no media_id stored — will retry on next use", entity_type, char["name"])
+                uuid_from_url = _extract_uuid_from_url(output_url)
+                if uuid_from_url:
+                    await crud.update_character(char["id"], media_id=uuid_from_url)
+                    logger.info("%s '%s' extracted UUID from URL fallback: media_id=%s", entity_type, char["name"], uuid_from_url)
+                    return {"data": {"media": [{"name": uuid_from_url}]}}
+                logger.warning("%s '%s' upload failed, no media_id stored — will retry upload on next attempt", entity_type, char["name"])
                 return {"error": f"Upload failed for {char['name']} — image generated but could not get UUID media_id"}
 
     return result


### PR DESCRIPTION
## Summary
- When `uploadImage` fails after successful `batchGenerateImages`, the worker now retries **only the upload** instead of regenerating the image (which burned credits on each retry)
- Added UUID extraction from GCS URL as a fallback when upload is unavailable
- Prevents wasting 5x credits per entity on transient upload failures

## Test plan
- [x] Generate a reference image, verify it completes in 1 generation
- [x] Simulate upload failure (disconnect extension mid-upload), verify retry only re-uploads
- [x] Verify UUID extraction from GCS URL works when upload is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)